### PR TITLE
fix(logger): catch errors when flushing

### DIFF
--- a/src/utils/logger.tsx
+++ b/src/utils/logger.tsx
@@ -25,7 +25,11 @@ logger = pino(
 );
 
 setInterval(function () {
-  logger.flush();
+  try {
+    logger.flush();
+  } catch (err) {
+    // logger failed to flush. that's okay
+  }
 }, 10000).unref();
 
 export function cliLogLevelToPinoLogLevel(logLevel: number): string {
@@ -46,8 +50,12 @@ export function cliLogLevelToPinoLogLevel(logLevel: number): string {
 export const pinoFinalHandler = pino.final(
   logger,
   (err, finalLogger, evt, noExit = false) => {
-    finalLogger.info(`${evt} caught`);
-    if (err) finalLogger.error(err, 'error caused exit');
+    try {
+      finalLogger.info(`${evt} caught`);
+      if (err) finalLogger.error(err, 'error caused exit');
+    } catch (err) {
+      // carry on we got to leave
+    }
     if (!noExit) process.exit(err ? 1 : 0);
   }
 );


### PR DESCRIPTION
<!-- Describe your Pull Request -->

In some cases it seems like people are hitting an error `sonic boom is not ready yet`. From my research it appears to be triggered by `sonic-boom` (the log writer) during flushing (https://github.com/mcollina/sonic-boom/blob/63bc3a4024c17302c7b0d4d3d0ca2ee0f2e772a9/index.js#L280-L282). The flushing logic was taken from the `pino` website. I can't reproduce the issue myself but for safety we'll catch any errors during the flushing and during final logging and silently continue. The user experience is more important here than the logs themselves.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
